### PR TITLE
fix 'Jekyll serve' fails on Ruby 3.0 (#4)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,9 @@
 source "https://rubygems.org"
 
 gem 'thin'
-gem 'jekyll', '3.8.5'
+gem 'jekyll'
+gem 'webrick'
+gem 'kramdown-parser-gfm'
 gem 'jekyll-feed'
 # gem 'jekyll-jupyter-notebook'
 


### PR DESCRIPTION
Ruby3.0 において `bundle exec jekyll serve` が失敗する問題を解決。